### PR TITLE
Packet reordering and packet loss handling

### DIFF
--- a/det.py
+++ b/det.py
@@ -189,6 +189,9 @@ class Exfiltration(object):
         fname = files[jobid]['filename']
         filename = "%s.%s" % (fname.replace(
             os.path.pathsep, ''), time.strftime("%Y-%m-%d.%H:%M:%S", time.gmtime()))
+        #Reorder packets before reassembling / ugly one-liner hack
+        files[jobid]['packets_number'], files[jobid]['data'] = \
+                [list(x) for x in zip(*sorted(zip(files[jobid]['packets_number'], files[jobid]['data'])))]
         content = ''.join(str(v) for v in files[jobid]['data']).decode('hex')
         content = aes_decrypt(content, self.KEY)
         if COMPRESSION:
@@ -222,7 +225,7 @@ class Exfiltration(object):
                     # making sure there's a jobid for this file
                     if (jobid in files and message[1] not in files[jobid]['packets_number']):
                         files[jobid]['data'].append(''.join(message[2:]))
-                        files[jobid]['packets_number'].append(message[1])
+                        files[jobid]['packets_number'].append(int(message[1]))
         except:
             raise
             pass


### PR DESCRIPTION
These changes aim to circumvent some problems that may occur when packets don't arrive in the right order (due to network latencies or short sleep times):

- The first commit is for reordering the intermediate packets upon receival of the last ("done") packet.
- The second commit handles the case when the last ("done") packet arrives while some intermediate packets are still on their way to the server: In this case, the last packet's id is used to deduce the number of packets composing the entire message, and the retrieve_file() function can be called when this number is met.